### PR TITLE
Move racer.tab related functions to translate.c

### DIFF
--- a/swep1rcr.exe/RE:-Text-functions.md
+++ b/swep1rcr.exe/RE:-Text-functions.md
@@ -1,38 +1,4 @@
-# Lookup text entry
 
-```C
-//----- (00421360) --------------------------------------------------------
-const char *__cdecl sub_421360(const char *a1)
-{
-  const char *result; // eax
-  char *v2; // edi
-  char *v3; // eax
-  const char **v4; // eax
-  CHAR *v5; // [esp+Ch] [ebp-104h]
-  CHAR SrcStr; // [esp+10h] [ebp-100h]
-
-  v5 = &SrcStr;
-  if ( !a1 )
-    return 0;
-  if ( !*a1 || *a1 != 47 || strlen(a1) == 1 )
-    return a1;
-  v2 = strchr(a1 + 1, 47) + 1;
-  if ( !lpSrcStr )
-    return v2;
-  strncpy(&SrcStr, a1 + 1, 0xFEu);
-  v3 = strchr(&SrcStr, 47);
-  if ( v3 )
-    *v3 = 0;
-  sub_4AB5D0(&SrcStr);
-  v4 = (const char **)bsearch(&v5, dword_4EB3C4, dword_4EB3CC, 4u, sub_4212F0);
-  if ( !v4 )
-    return v2;
-  result = &(*v4)[strlen(*v4) + 1];
-  if ( !*result )
-    return a1;
-  return result;
-}
-```
 
 ```C
 //----- (00421470) --------------------------------------------------------
@@ -52,7 +18,7 @@ const char *__cdecl sub_421470(const char *a1) {
 
 There are more functions nearby which look like text related too
 
-```
+```C
 //----- (00450530) --------------------------------------------------------
 int __cdecl sub_450530(__int16 a1, __int16 a2, char a3, char a4, char a5, char a6, int a7)
 {

--- a/swep1rcr.exe/translate.c
+++ b/swep1rcr.exe/translate.c
@@ -1,5 +1,15 @@
-```C
+/* Functions to load racer.tab and lookup translation entries */
+
+// This research is based on the patched US version
+
+//----- (004212F0) --------------------------------------------------------
+// Sorting function for text entries
+int __cdecl sub_4212F0(const void *a1, const void *a2) {
+  return strcmp(*(const char **)a1, *(const char **)a2);
+}
+
 //----- (00421120) --------------------------------------------------------
+// Parse racer.tab
 signed int __cdecl sub_421120(const char* a1) {
   int v4; // ebp
   char *v10; // edi
@@ -107,4 +117,35 @@ signed int __cdecl sub_421120(const char* a1) {
 
   return 1;
 }
-```
+
+//----- (00421360) --------------------------------------------------------
+// Lookup text entry from racer.tab
+const char *__cdecl sub_421360(const char *a1) {
+  const char *result; // eax
+  char *v2; // edi
+  char *v3; // eax
+  const char **v4; // eax
+  CHAR *v5; // [esp+Ch] [ebp-104h]
+  CHAR SrcStr; // [esp+10h] [ebp-100h]
+
+  v5 = &SrcStr;
+  if ( !a1 )
+    return 0;
+  if ( !*a1 || *a1 != 47 || strlen(a1) == 1 )
+    return a1;
+  v2 = strchr(a1 + 1, 47) + 1;
+  if ( !lpSrcStr )
+    return v2;
+  strncpy(&SrcStr, a1 + 1, 0xFEu);
+  v3 = strchr(&SrcStr, 47);
+  if ( v3 )
+    *v3 = 0;
+  sub_4AB5D0(&SrcStr);
+  v4 = (const char **)bsearch(&v5, dword_4EB3C4, dword_4EB3CC, 4u, sub_4212F0);
+  if ( !v4 )
+    return v2;
+  result = &(*v4)[strlen(*v4) + 1];
+  if ( !*result )
+    return a1;
+  return result;
+}


### PR DESCRIPTION
We should isolate the string getters from the rest of the text rendering as they are almost entirely unrelated.
There is another function in "RE:-Text-functions.md" which seems to handle splitting text key and the actual text, but I was not 100% sure so I left it where it is for now.

I also dislike the "translate.c" name as this is a more general gametext handling. Maybe we should rename it to gametext.c or something later.